### PR TITLE
Improved callback generation

### DIFF
--- a/source/gir/deleg_writer.d
+++ b/source/gir/deleg_writer.d
@@ -431,7 +431,10 @@ class DelegWriter
     if (callback.returnVal && callback.returnVal.origDType != "none")
       output ~= "return _retval;\n";
 
-    return output ~ "}\n";
+    output ~= "}\n";
+    output ~= "auto _" ~ delegParam.dName ~"CB = (" ~ delegParam.dName ~" is null) ? null : &_" ~ delegParam.dName ~"Callback;\n";
+    return output;
+
   }
 
   Param delegParam; /// The parameter of the callback delegate


### PR DESCRIPTION
Code below is generated with gidgen without this PR code merged:
```D
  void spawnAsync(PtyFlags ptyFlags, string workingDirectory, string[] argv, string[] envv, SpawnFlags spawnFlags, SpawnChildSetupFunc childSetup, int timeout, Cancellable cancellable, TerminalSpawnAsyncCallback callback)
  {
    extern(C) void _childSetupCallback(void* data)
    {
      auto _dlg = cast(SpawnChildSetupFunc*)data;

      (*_dlg)();
    }

    extern(C) void _callbackCallback(VteTerminal* terminal, GPid pid, GError* error, void* userData)
    {
      ptrThawGC(userData);
      auto _dlg = cast(TerminalSpawnAsyncCallback*)userData;

      (*_dlg)(ObjectG.getDObject!Terminal(cast(void*)terminal, No.Take), pid, error ? new ErrorG(cast(void*)error, No.Take) : null);
    }

    const(char)* _workingDirectory = workingDirectory.toCString(No.Alloc);
    char*[] _tmpargv;
    foreach (s; argv)
      _tmpargv ~= s.toCString(No.Alloc);
    _tmpargv ~= null;
    char** _argv = _tmpargv.ptr;

    char*[] _tmpenvv;
    foreach (s; envv)
      _tmpenvv ~= s.toCString(No.Alloc);
    _tmpenvv ~= null;
    char** _envv = _tmpenvv.ptr;

    auto _childSetup = freezeDelegate(cast(void*)&childSetup);
    auto _callback = freezeDelegate(cast(void*)&callback);
    vte_terminal_spawn_async(cast(VteTerminal*)cPtr, ptyFlags, _workingDirectory, _argv, _envv, spawnFlags, &_childSetupCallback, _childSetup, &thawDelegate, timeout, cancellable ? cast(GCancellable*)cancellable.cPtr(No.Dup) : null, &_callbackCallback, _callback);
  }
```

After the changes, gidgen produces the following:
```D
  void spawnAsync(PtyFlags ptyFlags, string workingDirectory, string[] argv, string[] envv, SpawnFlags spawnFlags, SpawnChildSetupFunc childSetup, int timeout, Cancellable cancellable, TerminalSpawnAsyncCallback callback)
  {
    extern(C) void _childSetupCallback(void* data)
    {
      auto _dlg = cast(SpawnChildSetupFunc*)data;

      (*_dlg)();
    }
    auto _childSetupCB = (childSetup is null) ? null : &_childSetupCallback;

    extern(C) void _callbackCallback(VteTerminal* terminal, GPid pid, GError* error, void* userData)
    {
      ptrThawGC(userData);
      auto _dlg = cast(TerminalSpawnAsyncCallback*)userData;

      (*_dlg)(ObjectG.getDObject!Terminal(cast(void*)terminal, No.Take), pid, error ? new ErrorG(cast(void*)error, No.Take) : null);
    }
    auto _callbackCB = (callback is null) ? null : &_callbackCallback;

    const(char)* _workingDirectory = workingDirectory.toCString(No.Alloc);
    char*[] _tmpargv;
    foreach (s; argv)
      _tmpargv ~= s.toCString(No.Alloc);
    _tmpargv ~= null;
    char** _argv = _tmpargv.ptr;

    char*[] _tmpenvv;
    foreach (s; envv)
      _tmpenvv ~= s.toCString(No.Alloc);
    _tmpenvv ~= null;
    char** _envv = _tmpenvv.ptr;

    auto _childSetup = (childSetup is null) ? null : freezeDelegate(cast(void*)&childSetup);
    GDestroyNotify _childSetupDestroyCB = (childSetup is null) ? null : &thawDelegate;
    auto _callback = (callback is null) ? null : freezeDelegate(cast(void*)&callback);
    vte_terminal_spawn_async(cast(VteTerminal*)cPtr, ptyFlags, _workingDirectory, _argv, _envv, spawnFlags, _childSetupCB, _childSetup, _childSetupDestroyCB, timeout, cancellable ? cast(GCancellable*)cancellable.cPtr(No.Dup) : null, _callbackCB, _callback);
  }
```

Now the following code works without segmentation faults:
(notice all callbacks are nulls as in many cases we do not need them)

```D
            terminal.spawnAsync(
                PtyFlags.Default,          // ptyFlags: PtyFlags
                workingDirectory,          // workingDirectory: string
                ["/usr/bin/env", "bash"],  // argv: string[]
                null,                      // envv: string[]
                SpawnFlags.Default,        // spawnFlags: SpawnFlags
                null,                      // childSetup: SpawnChildSetupFunc
                3600,                      // timeout: int
                null,                      // cancellable: Cancellable
                null                       // callback: TerminalSpawnAsyncCallback
            );
```
So in summary:
- destroy callback is passed only if the actual callback is not null
- also if the callback is null the actual user-data will be null
- it fixes the issue that prevents Vte.Terminal.spawnAsync() function to work as expected (see the above example how I call it in a test application). The PR that adds Vte to giddy https://github.com/Kymorphia/gid/pull/3 needs this PR code change in order to work.