### PR TITLE
This fixes the broken gHashTableToD code generation

### DIFF
--- a/source/gir/deleg_writer.d
+++ b/source/gir/deleg_writer.d
@@ -398,7 +398,7 @@ class DelegWriter
         templateParams = param.elemTypes[0].dType  ~ ", " ~ "GidOwnership." ~ param.ownership.to!dstring;
         break;
       case HashTable:
-        templateParams = "!(" ~ param.elemTypes[0].dType ~ ", " ~ param.elemTypes[1].dType ~ ", "
+        templateParams = param.elemTypes[0].dType ~ ", " ~ param.elemTypes[1].dType ~ ", "
           ~ "GidOwnership." ~ param.ownership.to!dstring;
         break;
       default:

--- a/source/gir/func_writer.d
+++ b/source/gir/func_writer.d
@@ -749,7 +749,7 @@ class FuncWriter
         templateParams = param.elemTypes[0].dType  ~ ", " ~ "GidOwnership." ~ param.ownership.to!dstring;
         break;
       case HashTable:
-        templateParams = "!(" ~ param.elemTypes[0].dType ~ ", " ~ param.elemTypes[1].dType ~ ", "
+        templateParams = param.elemTypes[0].dType ~ ", " ~ param.elemTypes[1].dType ~ ", "
           ~ "GidOwnership." ~ param.ownership.to!dstring;
         break;
       case Array, None:


### PR DESCRIPTION
While working on the Soup (libsoup) binding generation I found that gidgen generated the following invalid code:

```d
params = gHashTableToD!(!(string, string, GidOwnership.Full)(_params);
```

This PR fixes the issue and now correct gHashTableToD code is generated.