### PR TITLE
Simple way to display version information to the user.

### DIFF
--- a/source/gidgen.d
+++ b/source/gidgen.d
@@ -15,6 +15,9 @@ import gir.type_node;
 import std_includes;
 import xml_patch;
 
+// Before making a new release remove the '-alpha'
+enum __PROJECT_VERSION__ = "0.9.8-alpha";
+
 int main(string[] args)
 {
   LogLevel logLevel = LogLevel.warning;
@@ -29,6 +32,7 @@ int main(string[] args)
   bool enableReport;
   string reportFile;
   string reportOptions = "AllUnsupported";
+  bool displayVersion;
 
   try
   {
@@ -53,10 +57,12 @@ int main(string[] args)
         "dump-matches", "Dump XML patch selector matches", &XmlPatch.dumpSelectorMatches,
         "dump-traps", "Dump code trap actions", &codeTrapsDump,
         "trap", "Add gdb breakpoint 'action:regex', action: domain (help to list), regex: pattern to match", &traps,
+        "V|version", "Display version of the 'gidgen' application", &displayVersion,
     );
 
     if (helpInformation.helpWanted)
     {
+      writeln("gidgen v" ~ __PROJECT_VERSION__);
       defaultGetoptPrinter("GObject Introspection Dlang binding generator", helpInformation.options);
       return 0;
     }
@@ -76,6 +82,12 @@ int main(string[] args)
     if (reportOptions == "help")
     {
       displayReportOptionsHelp;
+      return 0;
+    }
+
+    if (displayVersion) {
+      writeln("gidgen v" ~ __PROJECT_VERSION__);
+      writeln("Copyright (c) 2024-2025 Kymorphia, PBC");
       return 0;
     }
   }


### PR DESCRIPTION
As the title says.

Examples:

Show version:

```
» ./gidgen -V
gidgen v0.9.8-alpha
Copyright (c) 2024-2025 Kymorphia, PBC
```

Version detail is also displayed in the help:

```
» ./gidgen -h
gidgen v0.9.8-alpha
GObject Introspection Dlang binding generator
..
..
```

I think it is possible to automate this with DUB using https://dub.pm/dub-reference/build_settings/#prebuildcommands  but I did not have time to look at how to do so. This is the main reason why I named the enum __PACKAGE_VERSION__ - so that I can later write a tool that can be used in any project. :)

I picked `-V` as short option because I wanted to reserve `-v` for eventual `verbose` mode.