### PR TITLE
Improved wildcard node selector and added 3 more unittests

### DIFF
--- a/source/xml_patch.d
+++ b/source/xml_patch.d
@@ -335,7 +335,7 @@ class XmlPatch
             continue;
           }
 
-          if (isFinel) // Do we have a matching node?
+          if (isFinal) // Do we have a matching node?
           {
             nodes ~= child;
 

--- a/source/xml_patch.d
+++ b/source/xml_patch.d
@@ -695,17 +695,7 @@ unittest
   auto patch = new XmlPatch();
   patch.parseDeleteCmd("root.nonexistent"d);
 
-  bool caught = false;
-  try
-  {
-    patch.apply(tree, null);
-  }
-  catch (XmlPatchError e)
-  {
-    caught = true;
-  }
-
-  assert(caught);
+  assertThrown!XmlPatchError(patch.apply(tree, null));
 }
 
 // Test error on empty XML value in set operation

--- a/source/xml_patch.d
+++ b/source/xml_patch.d
@@ -335,7 +335,7 @@ class XmlPatch
             continue;
           }
 
-          if (selArray.length == 1) // Do we have a matching node?
+          if (isFinel) // Do we have a matching node?
           {
             nodes ~= child;
 


### PR DESCRIPTION
Wildcard node selector (*.child)
When the first selector is *, the code now passes wildNode=true to recurseTree, enabling recursive search through all descendants instead of just direct children.

Wildcard in attribute values (root.node[test*])
Added a hasWildAttrs() method to XmlSelector that checks if any attribute value contains *. The multi-match logic now considers selectors with wildcard attributes as multi-match selectors, so all matching nodes are returned instead of just the first one.